### PR TITLE
INVALID_HANDLE_VALUE has different values on x86 & x86_64

### DIFF
--- a/src/user.rs
+++ b/src/user.rs
@@ -13,6 +13,7 @@ use std::ptr;
 
 use kernel32::*;
 use user32::{FindWindowExA, RegisterWindowMessageA, SendMessageA};
+use winapi::INVALID_HANDLE_VALUE;
 use winapi::memoryapi::FILE_MAP_WRITE;
 use winapi::minwindef::ATOM;
 use winapi::windef::HWND;
@@ -65,7 +66,7 @@ impl UserHandle {
             }
 
             let file_mapping = CreateFileMappingA(
-                0xffffffff as HANDLE,
+                INVALID_HANDLE_VALUE,
                 ptr::null_mut(),
                 PAGE_READWRITE,
                 0, FILE_MAPPING_LEN as u32,


### PR DESCRIPTION
`CreateFileMappingA` fails on x86_64 because `INVALID_HANDLE_VALUE` is `0xffffffffffffffff` on 64-bit Windows.

Also git repo missing tag for v0.4.0 release :)