### PR TITLE
64-bit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ You may also have a look to the [Hello World example][3].
 
 ## Known limitations
 
-* It is successfully tested in platform with i686, 32 bits architecture. Support
-for x86_64 is added, but was not fully tested yet.
+* It is successfully tested in platform with i686, 32 bits architecture.
+* It is successfully tested in platform with 64 bits architecture in user mode.
 * It has not been tested with WideFS. It is supposed to fail since it uses
 a different window identifier than FSUIPC.
 

--- a/src/local.rs
+++ b/src/local.rs
@@ -57,13 +57,17 @@ impl<'a> Handle<'a> for LocalHandle {
 pub struct LocalSession {
     handle: HWND,
     buffer: io::Cursor<Vec<u8>>,
+    #[cfg(target_pointer_width = "64")]
+    destinations: Vec<*mut u8>,
 }
 
 impl LocalSession {
     fn new(handle: HWND) -> Self {
         let mut session = LocalSession {
             handle: handle,
-            buffer: io::Cursor::new(Vec::with_capacity(4096))
+            buffer: io::Cursor::new(Vec::with_capacity(4096)),
+            #[cfg(target_pointer_width = "64")]
+            destinations: Vec::new(),
         };
         // First 4-bytes seems to be for a stack frame pointer that is not actually used
         session.buffer.set_position(4);
@@ -73,7 +77,16 @@ impl LocalSession {
 
 impl Session for LocalSession {
     fn read_bytes(&mut self, offset: u16, dest: *mut u8, len: usize) -> io::Result<usize> {
-        self.buffer.write_rsd(offset, dest, len)
+        #[cfg(target_pointer_width = "64")]
+        {
+            let idx = self.destinations.len();
+            self.destinations.push(dest);
+            self.buffer.write_rsd(offset, idx as *mut u8, len)
+        }
+        #[cfg(not(target_pointer_width = "64"))]
+        {
+            self.buffer.write_rsd(offset, dest, len)
+        }
     }
 
     fn write_bytes(&mut self, offset: u16, src: *const u8, len: usize) -> io::Result<usize> {
@@ -110,6 +123,16 @@ impl Session for LocalSession {
                 let header = self.buffer.read_header()?;
                 match &header {
                     &MsgHeader::ReadStateData { offset: _, len, target } => {
+                        #[cfg(target_pointer_width = "64")]
+                        let actual = {
+                            let idx = target as usize;
+                            *self.destinations.get(idx).ok_or_else(|| {
+                                io::Error::new(io::ErrorKind::InvalidData, "invalid destination index")
+                            })?
+                        };
+                        #[cfg(target_pointer_width = "64")]
+                        let mut output = MutRawBytes::new(actual, len);
+                        #[cfg(not(target_pointer_width = "64"))]
                         let mut output = MutRawBytes::new(target, len);
                         self.buffer.read_body(&header, &mut output)?;
                     },


### PR DESCRIPTION
Fixed STATUS_ACCESS_VIOLATION when tried to run on 64 bit

FSUIPC treats data destination pointer as 32-bit ptr. When a 64-bit ptr is passed, it is truncated, and the code is trying to access an address that doesn't exist or have access to. My solution is implemented with reference to [fsuipc-node](https://github.com/koesie10/fsuipc-node/blob/31e09d09987569cf43a1c091a630ff4bc6c10a4a/packages/fsuipc/src/IPCUser.cc#L257). The trick is to store 64-bit pointers in a vector, and past the indexes of the vector to FSUIPC instead.

Tested with user mode on FSUIPC 7.5.3 and XPUIPC 2.0.5.9
Local mode NOT tested